### PR TITLE
change S3 key format; add leading zeros in month, day, hour, and minute path segments

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "aws-sdk": "^2.238.1",
     "axios": "^0.16.2",
+    "luxon": "^2.3.0",
     "fs": "0.0.1-security",
     "gtfs-realtime-bindings": "^0.0.5",
     "request": "^2.88.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const fs = require('fs');
 const s3Helper = require('./s3Helper');
+const { DateTime } = require("luxon");
 
 const interval = 15000; // ms
 
@@ -66,12 +67,12 @@ setTimeout(function() {
 }, interval - Date.now() % interval);
 
 function saveVehicles() {
-  const currentTime = Date.now();
+  const currentDateTime = DateTime.utc();
 
   const promises = agenciesInfo.map((agencyInfo) => {
     return agencyInfo.provider.getVehicles(agencyInfo.config)
       .then((vehicles) => {
-        return s3Helper.writeToS3(s3Bucket, agencyInfo.id, currentTime, vehicles);
+        return s3Helper.writeToS3(s3Bucket, agencyInfo.id, currentDateTime, vehicles);
       })
       .catch((err) => {
         console.log(err);

--- a/src/s3Helper.js
+++ b/src/s3Helper.js
@@ -1,6 +1,5 @@
 const AWS = require('aws-sdk');
 var zlib = require('zlib');
-const { DateTime } = require("luxon");
 
 const s3 = new AWS.S3();
 
@@ -10,8 +9,7 @@ function compressData(data) {
   });
 }
 
-function writeToS3(s3Bucket, agency, currentTime, data) {
-  const currentDateTime = DateTime.utc();
+function writeToS3(s3Bucket, agency, currentDateTime, data) {
   const currentTimestamp = currentDateTime.toMillis();
   const dateTimePathSegment = currentDateTime.toFormat('yyyy/MM/dd/HH/mm');
   const s3Key = `${agency}/${dateTimePathSegment}/${agency}-${currentTimestamp}.json.gz`;

--- a/src/s3Helper.js
+++ b/src/s3Helper.js
@@ -1,5 +1,6 @@
 const AWS = require('aws-sdk');
 var zlib = require('zlib');
+const { DateTime } = require("luxon");
 
 const s3 = new AWS.S3();
 
@@ -10,14 +11,10 @@ function compressData(data) {
 }
 
 function writeToS3(s3Bucket, agency, currentTime, data) {
-  const currentDateTime = new Date(currentTime);
-  const year = currentDateTime.getUTCFullYear();
-  const month = currentDateTime.getUTCMonth()+1;
-  const day = currentDateTime.getUTCDate();
-  const hour = currentDateTime.getUTCHours();
-  const minute = currentDateTime.getUTCMinutes();
-  const second = currentDateTime.getUTCSeconds();
-  const s3Key = `${agency}/${year}/${month}/${day}/${hour}/${minute}/${second}/${agency}-${currentTime}.json.gz`;
+  const currentDateTime = DateTime.utc();
+  const currentTimestamp = currentDateTime.toMillis();
+  const dateTimePathSegment = currentDateTime.toFormat('yyyy/MM/dd/HH/mm');
+  const s3Key = `${agency}/${dateTimePathSegment}/${agency}-${currentTimestamp}.json.gz`;
 
   console.log(`writing s3://${s3Bucket}/${s3Key}`);
 

--- a/src/s3Helper.js
+++ b/src/s3Helper.js
@@ -12,7 +12,8 @@ function compressData(data) {
 function writeToS3(s3Bucket, agency, currentDateTime, data) {
   const currentTimestamp = currentDateTime.toMillis();
   const dateTimePathSegment = currentDateTime.toFormat('yyyy/MM/dd/HH/mm');
-  const s3Key = `${agency}/${dateTimePathSegment}/${agency}-${currentTimestamp}.json.gz`;
+  const version = 'v1';
+  const s3Key = `state/${version}/${agency}/${dateTimePathSegment}/${agency}_${version}_${currentTimestamp}.json.gz`;
 
   console.log(`writing s3://${s3Bucket}/${s3Key}`);
 


### PR DESCRIPTION
As mentioned in https://github.com/codeforpdx/opentransit-collector/issues/3, S3 keys created by Orion did not have leading zeros in the components with 2 digit numbers like months, days, hours, minutes, and seconds, so an alphabetic sort of the S3 keys doesn't put them in the correct order. This PR adds leading zeros to all path components and uses the luxon library (https://moment.github.io/luxon/#/) to simplify the code. 

This PR also changes the format of S3 keys created by opentransit-collector to be consistent with the format used by opentransit-metrics, for example:

state/v1/trimet/2022/02/12/19/07/trimet_v1_1644692835014.json.gz

S3 keys now have the prefix "state", which makes it possible to use the same S3 bucket for opentransit-collector and opentransit-metrics, so that people don't need to create two different S3 buckets if they want to run their own backend. The "state" prefix is also consistent with the new name of opentransit-state-api, which provides an API for the data contained under that prefix. However, compute_new.py in opentransit-metrics currently also uses the "state" prefix to keep track of the last date of statistics computed. Since we don't really have any statistics yet we could just rename the prefix used by compute_new.py to something else so that people don't think that this data is related to opentransit-state-api.

Like the S3 keys created by opentransit-metrics, the S3 key also contains a version code (v1) which would make migration easier if we change the data format in the future.

This PR also removes the seconds from the S3 path component since it doesn't seem like anything used it. This reduces the number of clicks when browsing the S3 bucket.

To run the new code locally, developers may need to run `docker-compose build` first to install the luxon library in the docker container.

This change would also require changing opentransit-state-api accordingly.