### PR TITLE
adding public-read acl to s3 helper put object

### DIFF
--- a/src/s3Helper.js
+++ b/src/s3Helper.js
@@ -20,6 +20,7 @@ function writeToS3(s3Bucket, agency, currentDateTime, data) {
   return compressData(data).then(encodedData => {
     return new Promise((resolve, reject) => {
       s3.putObject({
+        ACL: "public-read",
         Bucket: s3Bucket,
         Key: s3Key,
         Body: encodedData,


### PR DESCRIPTION
Goal: add "public-read" ACL to objects before putting them in S3. This allows for fetching vehicle state from S3 using aiohttp.

Changes: there's an ACL option in the standard AWS SDK. I updated the put object like the following:
```
s3.putObject({
        ACL: "public-read",
        Bucket: s3Bucket,
        Key: s3Key,
        Body: encodedData,
        ContentType: "application/json",
        ContentEncoding: "gzip",
      }
```
I tested with a file `curl -I https://opentransit-pdx.s3.us-west-2.amazonaws.com/state/v1/trimet/2022/03/01/04/58/trimet_v1_1646110695026.json.gz` that was put with the change. This returned `HTTP/1.1 200 OK`. And I tested with a file `curl -I https://opentransit-pdx.s3.us-west-2.amazonaws.com/state/v1/trimet/2022/03/01/04/58/trimet_v1_1646110707896.json.gz` that was put with the existing collector. This returned `HTTP/1.1 403 Forbidden`.